### PR TITLE
增添方法和修改有错代码

### DIFF
--- a/docs/doc/zh/ai_model_converter/maixcam.md
+++ b/docs/doc/zh/ai_model_converter/maixcam.md
@@ -79,7 +79,15 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io
 docker pull sophgo/tpuc_dev:latest
 ```
 
-> 在中国国内可能无法拉取或者速度慢，可以设置国内的镜像，可自行搜索或者参考[docker 设置代理，以及国内加速镜像设置](https://neucrack.com/p/286)。
+如果docker拉取失败，可以通过以下方式进行下载：
+```shell
+wget https://sophon-file.sophon.cn/sophon-prod-s3/drive/24/06/14/12/sophgo-tpuc_dev-v3.2_191a433358ad.tar.gz
+docker load -i sophgo-tpuc_dev-v3.2_191a433358ad.tar.gz
+```
+这个方法参考[tpu-mlir官方docker环境配置](https://github.com/sophgo/tpu-mlir/blob/master/README_cn.md)。
+
+此外你也可以设置国内的镜像，可自行搜索或者参考[docker 设置代理，以及国内加速镜像设置](https://neucrack.com/p/286)。
+
 
 ### 运行容器
 

--- a/docs/doc/zh/peripheral/pinmap.md
+++ b/docs/doc/zh/peripheral/pinmap.md
@@ -35,7 +35,7 @@ update:
 介绍了那么多，其实通过 MaixPy 使用 Pinmap 来管理引脚功能很简单：
 
 ```python
-from maix.peripheral import pinmap
+from maix import pinmap
 
 print(pinmap.get_pins())
 

--- a/docs/doc/zh/vision/image_ops.md
+++ b/docs/doc/zh/vision/image_ops.md
@@ -136,7 +136,7 @@ img.draw_string(10, 10, "Hello MaixPy", image.Color.from_rgb(255, 0, 0), scale=2
 获取字体的宽度和高度：
 
 ```python
-w, h = img.string_size("Hello MaixPy", scale=2)
+w, h = image.string_size("Hello MaixPy", scale=2)
 print(w, h)
 ```
 


### PR DESCRIPTION
1.在《ONNX模型转给MaixCAM用》的章节中新增一种拉取docker镜像的方法 
2.更正《基本图像操作》章节中的img.string_size这个错误方法
3.更正《PINMAP使用》这一章节中的from maix.peripheral这个导包错误